### PR TITLE
Fix navigation bar shadow appearing on initial view

### DIFF
--- a/Amble/AppDelegate.swift
+++ b/Amble/AppDelegate.swift
@@ -19,9 +19,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     let vcID: String!
     
     if Locksmith.loadDataForUserAccount(userAccount: "Amble") != nil {
-      vcID = "initialViewController"
+      vcID = "InitialViewController"
     } else {
-      vcID = "profileViewController"
+      vcID = "ProfileViewController"
     }
     
     let vc = storyboard.instantiateViewController(withIdentifier: vcID)

--- a/Amble/Base.lproj/Main.storyboard
+++ b/Amble/Base.lproj/Main.storyboard
@@ -32,7 +32,7 @@
         <!--Profile View Controller-->
         <scene sceneID="wg7-f3-ORb">
             <objects>
-                <viewController storyboardIdentifier="profileViewController" id="8rJ-Kc-sve" customClass="ProfileViewController" customModule="Amble" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="ProfileViewController" id="8rJ-Kc-sve" customClass="ProfileViewController" customModule="Amble" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="L7p-HK-0SC"/>
                         <viewControllerLayoutGuide type="bottom" id="Djb-ko-YwX"/>
@@ -67,7 +67,7 @@
                                 <rect key="frame" x="0.0" y="28" width="375" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="DPz-t9-IvH" id="c9Z-dk-u1H">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </tableViewCellContentView>
                             </tableViewCell>
@@ -85,7 +85,7 @@
         <!--Initial View Controller-->
         <scene sceneID="mzK-LN-cDT">
             <objects>
-                <viewController storyboardIdentifier="initialViewController" id="95L-dV-X0L" customClass="InitialViewController" customModule="Amble" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="InitialViewController" id="95L-dV-X0L" customClass="InitialViewController" customModule="Amble" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="qLD-0W-Ifq"/>
                         <viewControllerLayoutGuide type="bottom" id="Iph-H5-hip"/>

--- a/Amble/Login/EntryViewController.swift
+++ b/Amble/Login/EntryViewController.swift
@@ -134,7 +134,7 @@ extension EntryViewController: UITableViewDataSource, UITableViewDelegate {
 extension EntryViewController: UIScrollViewDelegate {
   
   func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
-    self.navigationController?.navigationBar.shadowImage = UIColor.flatWhite.generateImage()
+    self.navigationController?.navigationBar.shadowImage = nil
   }
   
   func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
@@ -230,7 +230,7 @@ extension EntryViewController {
       }
       
       let storyboard = UIStoryboard(name: "Main", bundle: nil)
-      let vc = storyboard.instantiateViewController(withIdentifier: "profileViewController")
+      let vc = storyboard.instantiateViewController(withIdentifier: "ProfileViewController")
       let navController = UINavigationController(rootViewController: vc)
       
       self.present(navController, animated: true, completion: nil)

--- a/Amble/Login/InitialViewController.swift
+++ b/Amble/Login/InitialViewController.swift
@@ -25,6 +25,12 @@ class InitialViewController: UIViewController {
     animateLogo()
     self.setCustomBackButton(image: UIImage(named: "back-button"))
   }
+  
+  override func viewWillAppear(_ animated: Bool) {
+    if self.navigationController?.navigationBar.shadowImage == nil {
+      self.navigationController?.navigationBar.shadowImage = UIImage()
+    }
+  }
 }
 
 // MARK: - Private helper functions


### PR DESCRIPTION
When register view is scrolled and the back button is pressed, the shadow image of the navigation bar now does not appear on the navigation bar of the initial view.

Also:

- Change colour of navigation bar shadow
- Capitalise storyboard IDs of view controllers