### PR TITLE
Update user struct to conform to new login API response

### DIFF
--- a/Amble/Login/EntryViewController.swift
+++ b/Amble/Login/EntryViewController.swift
@@ -220,7 +220,13 @@ extension EntryViewController {
     
     switch response {
     case .success(let json):
-      let user = User(username: (json["user"].stringValue), jwt: json["jwt"].stringValue)
+      let userJSON = json["user"]
+      let user = User(id: userJSON["id"].stringValue,
+                      username: userJSON["username"].stringValue,
+                      email: userJSON["email"].stringValue,
+                      firstName: userJSON["firstName"].stringValue,
+                      lastName: userJSON["lastName"].stringValue,
+                      jwt: json["jwt"].stringValue)
       
       // Save user data to keychain
       do {

--- a/Amble/User.swift
+++ b/Amble/User.swift
@@ -11,7 +11,11 @@ import Locksmith
 
 struct User: ReadableSecureStorable, CreateableSecureStorable, DeleteableSecureStorable, GenericPasswordSecureStorable {
   
+  let id: String
   let username: String
+  let email: String
+  let firstName: String
+  let lastName: String
   let jwt: String
   
   let service: String = Bundle.main.infoDictionary![String(kCFBundleIdentifierKey)] as? String ?? "Amble"
@@ -21,7 +25,11 @@ struct User: ReadableSecureStorable, CreateableSecureStorable, DeleteableSecureS
   }
   
   var data: [String : Any] {
-    return ["username": username,
+    return ["id": id,
+            "username": username,
+            "email": email,
+            "firstName": firstName,
+            "lastName": lastName,
             "jwt": jwt]
   }
 }


### PR DESCRIPTION
- API now returns entire user object when logging in or registering instead of just a username
- All details about user (id, name, etc.) are now stored in keychain (may need to change in future)