### PR TITLE
Fix lag when scrolling in profile view

### DIFF
--- a/Amble/ProfileViewController.swift
+++ b/Amble/ProfileViewController.swift
@@ -60,12 +60,17 @@ extension ProfileViewController: UICollectionViewDataSource {
     cell.imageView.layer.cornerRadius = 8
     cell.imageView.clipsToBounds = true
     
-    do {
-      if let url = URL(string: walk.image) {
-        try cell.imageView.image = UIImage(data: Data(contentsOf: url))
+    DispatchQueue.global().async {
+      do {
+        if let url = URL(string: walk.image) {
+          let walkImage = try UIImage(data: Data(contentsOf: url))
+          DispatchQueue.main.async(execute: {
+            cell.imageView.image = walkImage
+          })
+        }
+      } catch {
+        print("Error fetching photo")
       }
-    } catch {
-      print("Error fetching photo")
     }
     
     return cell


### PR DESCRIPTION
- Images were being downloaded on the main thread when cells were loaded, causing lag when they were appearing on screen again due to cells being reused
- Images are now downloaded on a background thread, with the cell's image still being updated on the main thread